### PR TITLE
Code updates to the Camel route to work correctly with Camel K Client Red Hat 1.8.2

### DIFF
--- a/projects/lab-01/MeterConsumer.java
+++ b/projects/lab-01/MeterConsumer.java
@@ -1,29 +1,46 @@
-// camel-k: language=java open-api=openapi-spec.yaml dependency=camel-openapi-java dependency=mvn:org.postgresql:postgresql:42.2.10 property=file:meters.properties secret=pg-login secret=rh-cloud-services-service-account
+// Maven dependencies used in this Camel route
+// camel-k: dependency=mvn:io.quarkus.quarkus-kubernetes-config
+// camel-k: dependency=mvn:io.quarkus:quarkus-jdbc-postgresql
+
+// OpenShift secrets used in this Camel route
+// camel-k: config=secret:rh-cloud-services-service-account
+// camel-k: config=secret:pg-login
+
+// Configuration files used in this Camel route
+// camel-k: config=file:meters.properties
+// camel-k: config=file:datasource.properties
+
+// OpenAPI file used to create the exposed route.
+// camel-k: open-api=file:openapi-spec.yaml
+
+// camel-k: language=java
 
 import org.apache.camel.builder.RouteBuilder;
 
-
 public class MeterConsumer extends RouteBuilder {
-
-
-    @Override
+    @Override 
     public void configure() throws Exception {
-
+        // This direct:create is called from line 20 on the openapi-spec.yaml file "operationId: create"
         from("direct:create").routeId("MetersFromAPI")
             .throttle(3).timePeriodMillis(20000)
+            // Convert received JSON data into Java objects, reference: https://camel.apache.org/components/3.20.x/eips/marshal-eip.html
             .unmarshal().json()
+            // Set headers from data sent by HTTP payload (your curl statement)
             .setHeader("meterId",simple("${body.[value][meterId]}"))
             .setHeader("status",simple("${body.[value][status]}"))
+            // Construct SQL INSERT statement
             .setBody(simple("INSERT INTO meter_update(meter_id, timestamp, status_text) VALUES ('${headers.meterId}', to_timestamp(${body.[value][timestamp]}), '${headers.status}');"))
             .log("SQL INSERT statement: ${body}")
-            .to("jdbc:dataSource")
+            // Send SQL INSERT statement PostGreSQL
+            .to("jdbc:default")
+            // Construct SQL SELECT statement
             .setBody(simple("SELECT address, id as meter_id, '${headers.status}' as status_text , latitude, longitude FROM meter where id = '${headers.meterId}' ;"))
             .log("SQL SELECT statement: ${body}")
-            .to("jdbc:dataSource")
+            // Send SQL SELECT statement to PostGreSQL
+            .to("jdbc:default")
+            // Convert Java objects back to JSON, reference: https://camel.apache.org/components/3.20.x/eips/marshal-eip.html
             .marshal().json()
+            // Send JSON data from PostGreSQL statement to Kafka cluster
             .to("kafka:{{producer.topic}}");
-
-
-
     }
 }

--- a/projects/lab-01/meters.properties
+++ b/projects/lab-01/meters.properties
@@ -1,12 +1,20 @@
-mgd.kafka.username={{secret:rh-cloud-services-service-account/client-id}}
-mgd.kafka.password={{secret:rh-cloud-services-service-account/client-secret}}
+### SASL SSL config for Kafka connection.
 
-# SASL SSL config for Kafka connection. Remember to replace the broker URL!
-camel.component.kafka.brokers=REPLACE_ME
+# *** \/\/\/ IMPORTANT \/\/\/ ***
+# REPLACE THE "REPLACEME" BELOW WITH YOUR KAFKA BOOTSTRAP SERVER CONNECTION STRING
+# You can find this bootstrap server in "Lab 1 - Provision a Managed Kafka cluster - Task 3 of 4"
+camel.component.kafka.brokers=REPLACEME
+# *** /\/\/\ IMPORTANT /\/\/\ ***
+
+### DO NOT MODIFY ANYTHING UNDER THIS LINE ###
+
 camel.component.kafka.security-protocol=SASL_SSL
 camel.component.kafka.sasl-mechanism=PLAIN
 camel.component.kafka.sasl-jaas-config=org.apache.kafka.common.security.plain.PlainLoginModule required username="${mgd.kafka.username}" password="${mgd.kafka.password}";
 kafka.serializerClass=kafka.serializer.StringEncoder
+
+mgd.kafka.username={{secret:rh-cloud-services-service-account/client-id}}
+mgd.kafka.password={{secret:rh-cloud-services-service-account/client-secret}}
 
 # Kafka meter producer properties
 producer.topic=hydrated-meter-events
@@ -18,14 +26,16 @@ consumer.maxPollRecords=5000
 consumer.consumersCount=1
 consumer.seekTo=beginning
 
-# Reference DB login secret for username and password
-db.username={{secret:pg-login/POSTGRES_USER}}
-db.password={{secret:pg-login/POSTGRES_PASSWORD}}
+### PostGreSQL database properties
 
-camel.component.jdbc.dataSource.user={{secret:pg-login/POSTGRES_USER}}
-camel.component.jdbc.dataSource.password={{secret:pg-login/POSTGRES_PASSWORD}}
-camel.component.jdbc.dataSource.serverName=iot-psql:5432
-camel.component.jdbc.dataSource.databaseName=city-info
-camel.component.jdbc.dataSource=#class:org.postgresql.ds.PGSimpleDataSource
+# Format: jdbc:postgresql//url-of-postgresql-db/database
+# reference: https://quarkus.io/guides/datasource
+quarkus.datasource.jdbc.url=jdbc:postgresql://iot-psql:5432/city-info
+quarkus.datasource.db-kind=postgresql
 
-
+# Using mvn:io.quarkus.quarkus-kubernetes-config depenency to allow Camel K to
+# pull the pg-login secret from OpenShift and insert it into the quarkus datasource below
+# reference: https://quarkus.io/guides/kubernetes-config
+quarkus.kubernetes-config.secrets=pg-login
+quarkus.datasource.username=${POSTGRES_USER}
+quarkus.datasource.password=${POSTGRES_PASSWORD}


### PR DESCRIPTION
This current git pull request fixes the code for `Lab 2 in the Multi-cloud AWS workshop`, as students cannot complete it. This is attributed to the locked `1.4` channel of the `Red Hat Integration - Camel K operator`, while `kamel ` in the Codeready workspace is on version `Camel K Client Red Hat 1.8.2`. To address this issue, upgrading the `Red Hat Integration - Camel K operator` to `1.8.2` is necessary, along with updating the dependencies and config options in the camel k route's code to accommodate the latest features and eliminate deprecation warnings.

The proposed code changes in this commit ensure the proper functioning of the camel k routes with `1.8.2` and add explanatory comments to aid students in comprehending the code's operation.